### PR TITLE
630:P2 (#25) Extract staff view_flights workflow into service

### DIFF
--- a/app/routes/staff.py
+++ b/app/routes/staff.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import json
 from app.models import db
 from flask_wtf.csrf import CSRFProtect
+from app.services.staff_service import fetch_flights_for_airline
 
 staff = Blueprint('staff', __name__, url_prefix='/staff')
 STAFF_DASHBOARD_ENDPOINT = "staff.dashboard"
@@ -306,53 +307,78 @@ def approve_staff():
         cursor.close()
         connection.close()
 
-
 @staff.route('/view_flights')
 @staff_required
 def view_flights():
     """View and filter flights"""
     db = current_app.config['GET_DB']()
-    cursor = db.cursor()
 
-    # Build query based on filters
-    base_query = """
-        SELECT f.*, a1.airport_city as departure_city, 
-               a2.airport_city as arrival_city
-        FROM flight f
-        JOIN airport a1 ON f.departure_airport = a1.airport_name
-        JOIN airport a2 ON f.arrival_airport = a2.airport_name
-        WHERE f.airline_name = %s
-    """
-    params = [session['airline_name']]
+    filters = {
+        "start_date": request.args.get("start_date"),
+        "end_date": request.args.get("end_date"),
+        "source": request.args.get("source"),
+        "destination": request.args.get("destination"),
+    }
 
-    if request.args.get('start_date'):
-        base_query += " AND f.departure_time >= %s"
-        params.append(request.args.get('start_date'))
-    if request.args.get('end_date'):
-        base_query += " AND f.departure_time <= %s"
-        params.append(request.args.get('end_date'))
-    if request.args.get('source'):
-        base_query += " AND (a1.airport_name LIKE %s OR a1.airport_city LIKE %s)"
-        search = f"%{request.args.get('source')}%"
-        params.extend([search, search])
-    if request.args.get('destination'):
-        base_query += " AND (a2.airport_name LIKE %s OR a2.airport_city LIKE %s)"
-        search = f"%{request.args.get('destination')}%"
-        params.extend([search, search])
+    flights = fetch_flights_for_airline(db, session['airline_name'], filters)
 
-    base_query += " ORDER BY f.departure_time"
-
-    cursor.execute(base_query, tuple(params))
-    flights = cursor.fetchall()
-
-    # Get staff permissions for template
+    # Get staff permissions for template (kept in route for now)
     staff_permissions = get_staff_permissions(session['user'])
 
-    cursor.close()
+    db.close()
 
-    return render_template('staff/view_flights.html',
-                           flights=flights,
-                           staff={'permissions': staff_permissions})
+    return render_template(
+        'staff/view_flights.html',
+        flights=flights,
+        staff={'permissions': staff_permissions},
+    )
+
+# @staff.route('/view_flights')
+# @staff_required
+# def view_flights():
+#     """View and filter flights"""
+#     db = current_app.config['GET_DB']()
+#     cursor = db.cursor()
+
+#     # Build query based on filters
+#     base_query = """
+#         SELECT f.*, a1.airport_city as departure_city, 
+#                a2.airport_city as arrival_city
+#         FROM flight f
+#         JOIN airport a1 ON f.departure_airport = a1.airport_name
+#         JOIN airport a2 ON f.arrival_airport = a2.airport_name
+#         WHERE f.airline_name = %s
+#     """
+#     params = [session['airline_name']]
+
+#     if request.args.get('start_date'):
+#         base_query += " AND f.departure_time >= %s"
+#         params.append(request.args.get('start_date'))
+#     if request.args.get('end_date'):
+#         base_query += " AND f.departure_time <= %s"
+#         params.append(request.args.get('end_date'))
+#     if request.args.get('source'):
+#         base_query += " AND (a1.airport_name LIKE %s OR a1.airport_city LIKE %s)"
+#         search = f"%{request.args.get('source')}%"
+#         params.extend([search, search])
+#     if request.args.get('destination'):
+#         base_query += " AND (a2.airport_name LIKE %s OR a2.airport_city LIKE %s)"
+#         search = f"%{request.args.get('destination')}%"
+#         params.extend([search, search])
+
+#     base_query += " ORDER BY f.departure_time"
+
+#     cursor.execute(base_query, tuple(params))
+#     flights = cursor.fetchall()
+
+#     # Get staff permissions for template
+#     staff_permissions = get_staff_permissions(session['user'])
+
+#     cursor.close()
+
+#     return render_template('staff/view_flights.html',
+#                            flights=flights,
+#                            staff={'permissions': staff_permissions})
 
 
 @staff.route('/change_status/<flight_num>', methods=['POST'])

--- a/app/services/staff_service.py
+++ b/app/services/staff_service.py
@@ -1,9 +1,45 @@
-"""
-Service-layer functions for staff workflows.
+def fetch_flights_for_airline(db, airline_name, filters):
+    """
+    Fetch flights for an airline with optional filters.
+    Extracted from staff.view_flights route.
+    filters keys: start_date, end_date, source, destination
+    """
+    cursor = db.cursor()
 
-Goal: keep business rules + DB orchestration out of Flask route handlers.
-Routes in app/routes/staff.py should eventually call functions here.
+    base_query = """
+        SELECT f.*, a1.airport_city as departure_city,
+               a2.airport_city as arrival_city
+        FROM flight f
+        JOIN airport a1 ON f.departure_airport = a1.airport_name
+        JOIN airport a2 ON f.arrival_airport = a2.airport_name
+        WHERE f.airline_name = %s
+    """
+    params = [airline_name]
 
-This file is intentionally a scaffold for Issue #24.
-Workflow extraction happens in follow-up issues (#25, #26).
-"""
+    start_date = filters.get("start_date")
+    end_date = filters.get("end_date")
+    source = filters.get("source")
+    destination = filters.get("destination")
+
+    if start_date:
+        base_query += " AND f.departure_time >= %s"
+        params.append(start_date)
+    if end_date:
+        base_query += " AND f.departure_time <= %s"
+        params.append(end_date)
+    if source:
+        base_query += " AND (a1.airport_name LIKE %s OR a1.airport_city LIKE %s)"
+        search = f"%{source}%"
+        params.extend([search, search])
+    if destination:
+        base_query += " AND (a2.airport_name LIKE %s OR a2.airport_city LIKE %s)"
+        search = f"%{destination}%"
+        params.extend([search, search])
+
+    base_query += " ORDER BY f.departure_time"
+
+    try:
+        cursor.execute(base_query, tuple(params))
+        return cursor.fetchall()
+    finally:
+        cursor.close()

--- a/tests/test_staff_service.py
+++ b/tests/test_staff_service.py
@@ -1,0 +1,16 @@
+from flask import current_app
+from app.services.staff_service import fetch_flights_for_airline
+
+def test_fetch_flights_for_airline_returns_list(app):
+    with app.app_context():
+        db = current_app.config["GET_DB"]()
+        try:
+            flights = fetch_flights_for_airline(
+                db,
+                "CSCI Air",
+                {"start_date": None, "end_date": None, "source": None, "destination": None},
+            )
+            assert flights is not None
+            assert isinstance(flights, list)
+        finally:
+            db.close()


### PR DESCRIPTION
Closes #25

Summary
- Extracted staff view_flights query building/execution into app/services/staff_service.py.
- Simplified route to parse filters → call service → render.
- Added test coverage for the new service function.

Verification
- python -m pytest -q (7 passed)
- Manual: opened /staff/view_flights with and without filters; page loads and results look the same.

Evidence
- Separation of concerns: DB orchestration moved out of route, enabling easier testing and future reuse.