### PR TITLE
630:P2 (#26) Extract staff view_airplanes workflow into service

### DIFF
--- a/app/routes/staff.py
+++ b/app/routes/staff.py
@@ -7,6 +7,7 @@ import json
 from app.models import db
 from flask_wtf.csrf import CSRFProtect
 from app.services.staff_service import fetch_flights_for_airline
+from app.services.staff_service import fetch_airplanes_for_airline
 
 staff = Blueprint('staff', __name__, url_prefix='/staff')
 STAFF_DASHBOARD_ENDPOINT = "staff.dashboard"
@@ -992,23 +993,12 @@ def add_booking_agent():
 def view_airplanes():
     """View and manage airplanes"""
     db = current_app.config['GET_DB']()
-    cursor = db.cursor()
-
     try:
-        # Query to fetch airplanes for the airline
-        query = """
-            SELECT airplane_id, seats
-            FROM airplane
-            WHERE airline_name = %s
-            ORDER BY airplane_id
-        """
-        cursor.execute(query, (session['airline_name'],))
-        airplanes = cursor.fetchall()
-
+        airplanes = fetch_airplanes_for_airline(db, session['airline_name'])
         return render_template('staff/view_airplanes.html', airplanes=airplanes)
     except Exception as e:
         flash("An error occurred while fetching airplanes. Please try again.", "danger")
         print("Error:", e)
         return redirect(url_for('STAFF_DASHBOARD_ENDPOINT'))
     finally:
-        cursor.close()
+        db.close()

--- a/app/services/staff_service.py
+++ b/app/services/staff_service.py
@@ -43,3 +43,20 @@ def fetch_flights_for_airline(db, airline_name, filters):
         return cursor.fetchall()
     finally:
         cursor.close()
+
+def fetch_airplanes_for_airline(db, airline_name):
+    """
+    Fetch airplanes for an airline. Extracted from staff.view_airplanes route.
+    """
+    cursor = db.cursor()
+    try:
+        query = """
+            SELECT airplane_id, seats
+            FROM airplane
+            WHERE airline_name = %s
+            ORDER BY airplane_id
+        """
+        cursor.execute(query, (airline_name,))
+        return cursor.fetchall()
+    finally:
+        cursor.close()

--- a/tests/test_staff_service.py
+++ b/tests/test_staff_service.py
@@ -1,5 +1,6 @@
 from flask import current_app
 from app.services.staff_service import fetch_flights_for_airline
+from app.services.staff_service import fetch_airplanes_for_airline
 
 def test_fetch_flights_for_airline_returns_list(app):
     with app.app_context():
@@ -12,5 +13,16 @@ def test_fetch_flights_for_airline_returns_list(app):
             )
             assert flights is not None
             assert isinstance(flights, list)
+        finally:
+            db.close()
+
+
+def test_fetch_airplanes_for_airline_returns_list(app):
+    with app.app_context():
+        db = current_app.config["GET_DB"]()
+        try:
+            airplanes = fetch_airplanes_for_airline(db, "CSCI Air")
+            assert airplanes is not None
+            assert isinstance(airplanes, list)
         finally:
             db.close()


### PR DESCRIPTION
Closes #26

Summary
- Extracted staff view_airplanes DB/query logic into app/services/staff_service.py.
- Simplified route to call service and focus on HTTP response.
- Extended service-level tests for airplane retrieval.

Verification
- python -m pytest -q (9 passed)

Evidence
- Further separation of concerns by moving DB orchestration out of staff routes, improving maintainability and testability.