### PR TITLE
630:P3 #30 Migrate agent routes to shared access policy

### DIFF
--- a/app/auth/access.py
+++ b/app/auth/access.py
@@ -1,0 +1,83 @@
+# app/auth/access.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import wraps
+from typing import Callable, Optional, Protocol, Tuple
+
+from flask import current_app, flash, redirect, session, url_for
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    allowed: bool
+    redirect_endpoint: str = "auth.login"
+    flash_message: Optional[str] = None
+    flash_category: str = "danger"
+
+
+class AccessPolicy(Protocol):
+    """Role-specific rules. Keep this tiny and behavior-preserving."""
+    def evaluate(self) -> AccessDecision: ...
+
+
+class CustomerPolicy:
+    def evaluate(self) -> AccessDecision:
+        if session.get("user_type") != "customer":
+            return AccessDecision(allowed=False)
+        return AccessDecision(allowed=True)
+
+
+class StaffPolicy:
+    def evaluate(self) -> AccessDecision:
+        if session.get("user_type") != "staff":
+            return AccessDecision(allowed=False)
+        return AccessDecision(allowed=True)
+
+
+class AgentPolicy:
+    def evaluate(self) -> AccessDecision:
+        if session.get("user_type") != "agent":
+            return AccessDecision(allowed=False)
+
+        # Preserve existing behavior: agent must be approved.
+        connection = current_app.config["GET_DB"]()
+        cursor = connection.cursor()
+        try:
+            cursor.execute(
+                """
+                SELECT approved
+                FROM booking_agent
+                WHERE email = %s
+                """,
+                (session.get("user"),),
+            )
+            result = cursor.fetchone()
+            if not result or not result.get("approved"):
+                return AccessDecision(
+                    allowed=False,
+                    flash_message="Your account is pending approval. Please contact airline staff.",
+                )
+        finally:
+            cursor.close()
+            connection.close()
+
+        return AccessDecision(allowed=True)
+
+
+def require_access(policy: AccessPolicy) -> Callable:
+    """Decorator factory to enforce access using a policy strategy."""
+    def decorator(view_func: Callable) -> Callable:
+        @wraps(view_func)
+        def wrapper(*args, **kwargs):
+            decision = policy.evaluate()
+            if decision.allowed:
+                return view_func(*args, **kwargs)
+
+            if decision.flash_message:
+                flash(decision.flash_message, decision.flash_category)
+
+            return redirect(url_for(decision.redirect_endpoint))
+
+        return wrapper
+    return decorator

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -2,6 +2,7 @@ from flask import Blueprint, render_template, request, session, redirect, url_fo
 from datetime import datetime, timedelta
 from functools import wraps
 from app.models import db
+from app.auth.access import require_access, AgentPolicy
 
 agent = Blueprint('agent', __name__)
 AGENT_SEARCH_FLIGHTS_ENDPOINT = "agent.search_flights"
@@ -36,7 +37,7 @@ def agent_required(f):
 
 
 @agent.route('/dashboard')  # Changed from /home to /dashboard
-@agent_required
+@require_access(AgentPolicy())
 def dashboard():
     """Agent dashboard showing summary and recent bookings"""
     connection = current_app.config['GET_DB']()
@@ -102,7 +103,7 @@ def dashboard():
 
 
 @agent.route('/flights', endpoint='my_flights')
-@agent_required
+@require_access(AgentPolicy())
 def view_flights():
     db = current_app.config['GET_DB']()
     cursor = db.cursor()
@@ -173,7 +174,7 @@ def view_flights():
 
 
 @agent.route('/commission', endpoint='commission')
-@agent_required
+@require_access(AgentPolicy())
 def view_commission():
     """View agent's commission with date range filtering"""
     connection = current_app.config['GET_DB']()
@@ -233,7 +234,7 @@ def view_commission():
 
 
 @agent.route('/top_customers', endpoint='top_customers')
-@agent_required
+@require_access(AgentPolicy())
 def view_top_customers():
     """View top customers by tickets and commission"""
     connection = current_app.config['GET_DB']()
@@ -292,7 +293,7 @@ def view_top_customers():
                            commission_amounts=commission_amounts)
 
 @agent.route('/search_flights', endpoint='search_flights')
-@agent_required
+@require_access(AgentPolicy())
 def search_flights():
     """Search flights for agents based on filters"""
     connection = current_app.config['GET_DB']()
@@ -341,7 +342,7 @@ def search_flights():
                            end_date=end_date)
 
 @agent.route('/book_ticket_for_customer', methods=['GET', 'POST'])
-@agent_required
+@require_access(AgentPolicy())
 def book_ticket_for_customer():
     connection = current_app.config['GET_DB']()
     cursor = connection.cursor()


### PR DESCRIPTION
-Problem: Role-based access logic duplicated across route modules → shotgun-surgery risk.
-Pattern: Strategy (AgentPolicy) + Factory Method (require_access(policy) decorator factory).
-Change: Agent routes now use @require_access(AgentPolicy()) instead of local agent_required.
-Behavior preserved:
    -Agent routes still exist (flask routes | grep -i agent)
    -Logged-out access redirects to login (evidence below)
-Verification:
python3 -m compileall app
flask run
curl -I http://127.0.0.1:5000/dashboard → 302 with Location: /login