### PR TITLE
630:P3 #34 Replace staff_service SQL concat with FlightQueryBuilder

### DIFF
--- a/app/services/flight_query_builder.py
+++ b/app/services/flight_query_builder.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+@dataclass
+class FlightQueryBuilder:
+    airline_name: str
+    _where: List[str] = field(default_factory=list)
+    _params: List[object] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Base query + required airline filter
+        self._base_sql = """
+            SELECT f.*, a1.airport_city as departure_city,
+                   a2.airport_city as arrival_city
+            FROM flight f
+            JOIN airport a1 ON f.departure_airport = a1.airport_name
+            JOIN airport a2 ON f.arrival_airport = a2.airport_name
+            WHERE f.airline_name = %s
+        """
+        self._params.append(self.airline_name)
+
+    def with_start_date(self, start_date: Optional[str]) -> "FlightQueryBuilder":
+        if start_date:
+            self._where.append("f.departure_time >= %s")
+            self._params.append(start_date)
+        return self
+
+    def with_end_date(self, end_date: Optional[str]) -> "FlightQueryBuilder":
+        if end_date:
+            self._where.append("f.departure_time <= %s")
+            self._params.append(end_date)
+        return self
+
+    def with_source(self, source: Optional[str]) -> "FlightQueryBuilder":
+        if source:
+            self._where.append("(a1.airport_name LIKE %s OR a1.airport_city LIKE %s)")
+            search = f"%{source}%"
+            self._params.extend([search, search])
+        return self
+
+    def with_destination(self, destination: Optional[str]) -> "FlightQueryBuilder":
+        if destination:
+            self._where.append("(a2.airport_name LIKE %s OR a2.airport_city LIKE %s)")
+            search = f"%{destination}%"
+            self._params.extend([search, search])
+        return self
+
+    def build(self) -> Tuple[str, List[object]]:
+        sql = self._base_sql
+        if self._where:
+            sql += " AND " + " AND ".join(self._where)
+        return sql, self._params

--- a/app/services/staff_service.py
+++ b/app/services/staff_service.py
@@ -1,3 +1,5 @@
+from app.services.flight_query_builder import FlightQueryBuilder
+
 def fetch_flights_for_airline(db, airline_name, filters):
     """
     Fetch flights for an airline with optional filters.
@@ -6,40 +8,23 @@ def fetch_flights_for_airline(db, airline_name, filters):
     """
     cursor = db.cursor()
 
-    base_query = """
-        SELECT f.*, a1.airport_city as departure_city,
-               a2.airport_city as arrival_city
-        FROM flight f
-        JOIN airport a1 ON f.departure_airport = a1.airport_name
-        JOIN airport a2 ON f.arrival_airport = a2.airport_name
-        WHERE f.airline_name = %s
-    """
-    params = [airline_name]
-
     start_date = filters.get("start_date")
     end_date = filters.get("end_date")
     source = filters.get("source")
     destination = filters.get("destination")
 
-    if start_date:
-        base_query += " AND f.departure_time >= %s"
-        params.append(start_date)
-    if end_date:
-        base_query += " AND f.departure_time <= %s"
-        params.append(end_date)
-    if source:
-        base_query += " AND (a1.airport_name LIKE %s OR a1.airport_city LIKE %s)"
-        search = f"%{source}%"
-        params.extend([search, search])
-    if destination:
-        base_query += " AND (a2.airport_name LIKE %s OR a2.airport_city LIKE %s)"
-        search = f"%{destination}%"
-        params.extend([search, search])
-
-    base_query += " ORDER BY f.departure_time"
+    builder = (
+        FlightQueryBuilder(airline_name)
+        .with_start_date(start_date)
+        .with_end_date(end_date)
+        .with_source(source)
+        .with_destination(destination)
+    )
+    query, params = builder.build()
+    query += " ORDER BY f.departure_time"
 
     try:
-        cursor.execute(base_query, tuple(params))
+        cursor.execute(query, tuple(params))
         return cursor.fetchall()
     finally:
         cursor.close()

--- a/tests/test_flight_query_builder.py
+++ b/tests/test_flight_query_builder.py
@@ -1,0 +1,18 @@
+from app.services.flight_query_builder import FlightQueryBuilder
+
+def test_builder_adds_filters_in_order():
+    sql, params = (
+        FlightQueryBuilder("CSCI Air")
+        .with_start_date("2026-02-01")
+        .with_end_date("2026-02-28")
+        .with_source("SFO")
+        .with_destination("LAX")
+        .build()
+    )
+
+    assert "WHERE f.airline_name = %s" in sql
+    assert "f.departure_time >= %s" in sql
+    assert "f.departure_time <= %s" in sql
+    assert "a1.airport_name LIKE %s" in sql
+    assert "a2.airport_name LIKE %s" in sql
+    assert params[0] == "CSCI Air"


### PR DESCRIPTION
Closes #34

Summary
- Introduced `FlightQueryBuilder` (`app/services/flight_query_builder.py`) to build `(sql, params)` using explicit filter methods.
- Refactored `fetch_flights_for_airline()` in `app/services/staff_service.py` to use the builder instead of conditional SQL string concatenation.
- Added unit tests for builder output + parameter ordering (`tests/test_flight_query_builder.py`).

Verification
- python3 -m pytest -q (10 passed)

Evidence
- Reduces risk of malformed SQL and mismatched parameter ordering by centralizing query construction in a Builder.
- Adding a new filter is now a new builder method + one call site (no more editing concatenated SQL across multiple if-blocks).