### PR TITLE
630:P3 #35 Validate flight status updates using State pattern

### DIFF
--- a/app/routes/staff.py
+++ b/app/routes/staff.py
@@ -8,6 +8,7 @@ from app.models import db
 from flask_wtf.csrf import CSRFProtect
 from app.services.staff_service import fetch_flights_for_airline
 from app.services.staff_service import fetch_airplanes_for_airline
+from app.services.flight_status import FlightStatusMachine
 
 staff = Blueprint('staff', __name__, url_prefix='/staff')
 STAFF_DASHBOARD_ENDPOINT = "staff.dashboard"
@@ -381,7 +382,6 @@ def view_flights():
 #                            flights=flights,
 #                            staff={'permissions': staff_permissions})
 
-
 @staff.route('/change_status/<flight_num>', methods=['POST'])
 @staff_required
 def change_status(flight_num):
@@ -395,9 +395,24 @@ def change_status(flight_num):
 
     cursor = db.cursor()
     try:
+        # Read current status for transition validation
         cursor.execute("""
-            UPDATE flight 
-            SET status = %s 
+            SELECT status
+            FROM flight
+            WHERE airline_name = %s AND flight_num = %s
+        """, (session['airline_name'], flight_num))
+        row = cursor.fetchone()
+        current_status = None
+        if row:
+            current_status = row.get("status") if hasattr(row, "get") else row[0]
+
+        decision = FlightStatusMachine.validate_transition(current_status, status)
+        if not decision.ok:
+            return jsonify({'error': decision.message}), 400
+
+        cursor.execute("""
+            UPDATE flight
+            SET status = %s
             WHERE airline_name = %s AND flight_num = %s
         """, (status, session['airline_name'], flight_num))
         db.commit()

--- a/app/services/flight_status.py
+++ b/app/services/flight_status.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Optional, Set
+
+
+@dataclass(frozen=True)
+class StatusDecision:
+    ok: bool
+    message: Optional[str] = None
+
+
+class FlightStatusMachine:
+    """
+    Small 'State' validator for flight statuses (and optional transitions).
+    Centralizes allowed values + transition rules.
+    """
+
+    # Keep aligned with what your UI already uses / expects.
+    ALLOWED: Set[str] = {
+        "On Time",
+        "Delayed",
+        "Cancelled",
+        "In Air",
+        "Arrived",
+    }
+
+    # Transition rules (kept permissive: if current is unknown, allow any ALLOWED)
+    TRANSITIONS: Dict[str, Set[str]] = {
+        "On Time": {"On Time", "Delayed", "Cancelled", "In Air", "Arrived"},
+        "Delayed": {"Delayed", "On Time", "Cancelled", "In Air", "Arrived"},
+        "In Air": {"In Air", "Arrived"},
+        "Arrived": {"Arrived"},
+        "Cancelled": {"Cancelled"},
+    }
+
+    @classmethod
+    def validate_transition(cls, current: Optional[str], requested: str) -> StatusDecision:
+        if requested not in cls.ALLOWED:
+            return StatusDecision(
+                ok=False,
+                message=f"Invalid status '{requested}'. Allowed: {sorted(cls.ALLOWED)}",
+            )
+
+        if not current or current not in cls.TRANSITIONS:
+            return StatusDecision(ok=True)
+
+        allowed_next = cls.TRANSITIONS[current]
+        if requested not in allowed_next:
+            return StatusDecision(
+                ok=False,
+                message=f"Invalid transition: '{current}' → '{requested}'. Allowed next: {sorted(allowed_next)}",
+            )
+
+        return StatusDecision(ok=True)


### PR DESCRIPTION
Closes #35

Summary
- Added `FlightStatusMachine` (State-style validator) in `app/services/flight_status.py` to centralize allowed statuses + transition rules.
- Updated `app/routes/staff.py::change_status()` to validate the requested status (and transition from current status) before updating the DB.
- Invalid statuses/transitions now return a clear error; valid updates behave the same as before.

Verification
- python3 -m pytest -q (all tests passing)


Evidence
- Removes “stringly-typed” status updates (Primitive Obsession) by enforcing valid states in one place.
- Transition rules are no longer scattered—future changes happen in `FlightStatusMachine` instead of route logic.